### PR TITLE
Bugfix: Don't over-escape Stimulus action tokens

### DIFF
--- a/app/helpers/attributes_and_token_lists/application_helper.rb
+++ b/app/helpers/attributes_and_token_lists/application_helper.rb
@@ -6,7 +6,7 @@ require "attributes_and_token_lists/token_list"
 module AttributesAndTokenLists
   module ApplicationHelper
     def token_list(*tokens)
-      TokenList.wrap(super(*tokens))
+      TokenList.wrap(build_tag_values(*tokens))
     end
     alias_method :class_names, :token_list
 

--- a/lib/attributes_and_token_lists/token_list.rb
+++ b/lib/attributes_and_token_lists/token_list.rb
@@ -2,6 +2,10 @@ module AttributesAndTokenLists
   class TokenList # :nodoc:
     include Enumerable
 
+    def self.split(tokens)
+      tokens.to_s.split(/\s+/)
+    end
+
     def self.wrap(value)
       if value.is_a? TokenList
         value
@@ -12,12 +16,12 @@ module AttributesAndTokenLists
           else Array(value)
           end
 
-        new tokens.flat_map { |token| token.to_s.split(/\s+/) }.reject(&:blank?)
+        new tokens.flat_map { |token| split(token) }.reject(&:blank?)
       end
     end
 
     def initialize(tokens)
-      @tokens = Set.new(tokens)
+      @tokens = Set[*tokens]
     end
 
     def union(other)

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -29,9 +29,9 @@ class AttributesAndTokenLists::ApplicationHelperTest < ActionView::TestCase
   end
 
   test "token_list accepts TokenList instances" do
-    tokens = token_list("one two", token_list("three"))
+    tokens = token_list("click->controller#one click->controller#two", token_list("click->controller#three"))
 
-    assert_equal "one two three", tokens.to_s
+    assert_equal "click->controller#one click->controller#two click->controller#three", tokens.to_s
   end
 
   test "token_list merges TokenList instances" do
@@ -169,21 +169,31 @@ class AttributesAndTokenLists::ApplicationHelperTest < ActionView::TestCase
   end
 
   test "tag.attributes automatically wraps data: { action: ... } values as TokenList instances" do
-    attributes = tag.attributes data: {action: "one two"}
+    attributes = tag.attributes data: {action: "click->controller#one click->controller#two"}
 
     tokens = attributes.dig(:data, :action)
 
     assert_kind_of AttributesAndTokenLists::TokenList, tokens
-    assert_equal %w[one two], tokens.to_a
+    assert_equal %w[click->controller#one click->controller#two], tokens.to_a
   end
 
   test "tag.attributes automatically wraps data-action values as TokenList instances" do
-    attributes = tag.attributes "data-action": "one two"
+    attributes = tag.attributes "data-action": "click->controller#one click->controller#two"
 
     tokens = attributes[:"data-action"]
 
     assert_kind_of AttributesAndTokenLists::TokenList, tokens
-    assert_equal %w[one two], tokens.to_a
+    assert_equal %w[click->controller#one click->controller#two], tokens.to_a
+  end
+
+  test "tag.attributes deep merges data-action values" do
+    left = tag.attributes data: {action: "click->controller#one"}
+    right = tag.attributes data: {action: "click->controller#two"}
+
+    tokens = left.merge(right).dig(:data, :action)
+
+    assert_kind_of AttributesAndTokenLists::TokenList, tokens
+    assert_equal %w[click->controller#one click->controller#two], tokens.to_a
   end
 
   test "tag.attributes automatically wraps data: { controller: ... } values as TokenList instances" do


### PR DESCRIPTION
When merging Action descriptors like
`[data-action="click->controller#action"]`, the `TokenList`
implementation was escaping the `>` too many times, resulting in broken
syntax like `&amp;amp;gt;`.

To resolve that issue, revert back to depending on the Action View
private `build_tag_values` method.