### PR TITLE
Support chaining view helpers from `Attributes` instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,11 @@ the version links.
 
 * Add `Attributes#with_attributes` and `Attributes#with_options` alias to enable
   decorating and chaining
+
+* Support chaining view helpers off `Attributes` instances
+
+  ```ruby
+  styled = tag.attributes(class: "my-link-class")
+
+  styled.link_to("A link", "/")
+  ```

--- a/lib/attributes_and_token_lists/attributes.rb
+++ b/lib/attributes_and_token_lists/attributes.rb
@@ -2,8 +2,6 @@ require "active_support/core_ext/hash/deep_transform_values"
 
 module AttributesAndTokenLists
   class Attributes # :nodoc:
-    delegate_missing_to :@attributes
-
     TOKEN_LIST_ATTRIBUTES = %i[
       class
       rel
@@ -100,6 +98,23 @@ module AttributesAndTokenLists
       end
     end
     alias_method :to_h, :to_hash
+
+    def method_missing(name, *arguments, **options, &block)
+      receiver =
+        if @attributes.respond_to?(name)
+          @attributes
+        elsif @view_context.respond_to?(name)
+          with_attributes
+        else
+          super
+        end
+
+      receiver.public_send(name, *arguments, **options, &block)
+    end
+
+    def respond_to_missing?(name, include_private = false)
+      @attributes.respond_to?(name) || @view_context.respond_to?(name)
+    end
 
     def inspect
       "#<%<class>s:0x%<addr>08x attributes=%<attributes>s>" %

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -238,6 +238,18 @@ class AttributesAndTokenLists::ApplicationHelperTest < ActionView::TestCase
     assert_equal %(<form data-controller="one two three"></form>), attributes.tag.form
   end
 
+  test "tag.attributes instances can chain view helper calls" do
+    attributes = tag.attributes(class: "one two").merge(class: "three")
+
+    assert_equal %(<a class="one two three" href="/">styled</a>), attributes.link_to("styled", "/")
+  end
+
+  test "tag.attributes instances raises NoMethodError when chaining missing methods" do
+    assert_raises NoMethodError do
+      tag.attributes(class: "ignored").some_junk_method
+    end
+  end
+
   test "with_attributes can have options decorated onto it" do
     with_attributes class: "one two" do |styled|
       assert_equal %(<a class="one two" href="/">styled</a>), styled.link_to("styled", "/")


### PR DESCRIPTION
For example:

```ruby
styled = tag.attributes(class: "my-link-class")

styled.link_to("A link", "/")
```

In order to achieve this behavior, remove the `delegate_missing_to
:@attributes` declaration (where `@attributes` is an instance of a
`Hash`) and replace it with a more thorough `#method_missing` definition
that first attempts to call the method on the `Hash` instance, falling
back to the `ActionView::Base` instance, then finally raising if neither
respond to the message.