### PR TITLE
`Attributes#to_hash`: Deep symbolize keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,6 @@ the version links.
 
   styled.link_to("A link", "/")
   ```
+
+* Deep symbolize `Attributes` keys when splatting or calling
+  `Attributes#to_hash`

--- a/lib/attributes_and_token_lists/attributes.rb
+++ b/lib/attributes_and_token_lists/attributes.rb
@@ -88,7 +88,7 @@ module AttributesAndTokenLists
       @tag_builder.attributes(to_hash)
     end
 
-    def to_hash
+    def to_h
       @attributes.deep_transform_values do |value|
         case value
         when Attributes then value.to_hash
@@ -97,7 +97,10 @@ module AttributesAndTokenLists
         end
       end
     end
-    alias_method :to_h, :to_hash
+
+    def to_hash
+      to_h.deep_symbolize_keys
+    end
 
     def method_missing(name, *arguments, **options, &block)
       receiver =

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -61,7 +61,7 @@ class AttributesAndTokenLists::ApplicationHelperTest < ActionView::TestCase
   test "tag.attributes can be splatted" do
     attributes = {id: 1, **tag.attributes(class: class_names("one"))}
 
-    assert_equal({:id => 1, "class" => class_names("one")}, attributes)
+    assert_equal({id: 1, class: class_names("one")}, attributes)
   end
 
   test "tag.attributes merges like a Hash of attributes" do


### PR DESCRIPTION
When splatting an `Attributes` instance or explicitly calling
`Attributes#to_hash`, deep transform all keys to symbols by calling
[ActiveSupport::HashWithIndifferentAccess#deep_symbolize_keys][].

[ActiveSupport::HashWithIndifferentAccess#deep_symbolize_keys]: https://edgeapi.rubyonrails.org/classes/ActiveSupport/HashWithIndifferentAccess.html#method-i-deep_symbolize_keys