### PR TITLE
Resolve merge conflict bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ the version links.
 
 ## main
 
+* Resolve `Attributes#merge` primitive value override bug
+
 * Decorate public interfaces instead of monkey-patching private ones
 
 * Introduce [standard](https://github.com/testdouble/standard) for style

--- a/lib/attributes_and_token_lists/attributes.rb
+++ b/lib/attributes_and_token_lists/attributes.rb
@@ -62,7 +62,7 @@ module AttributesAndTokenLists
         elsif value.respond_to?(:merge)
           value.merge(override)
         else
-          value
+          override
         end
       end
 

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -76,6 +76,12 @@ class AttributesAndTokenLists::ApplicationHelperTest < ActionView::TestCase
     assert_equal %(id="1" class="one" hidden="hidden"), attributes.to_s
   end
 
+  test "tag.attributes merges variable arguments, with the last key-value pairs serving as overrides" do
+    attributes = tag.attributes({type: nil}, {type: "button"}, type: "reset")
+
+    assert_equal %(type="reset"), attributes.to_s
+  end
+
   test "tag.attributes merges variable arguments, with a final override" do
     left = tag.attributes(id: 1)
     right = tag.attributes(class: "one")


### PR DESCRIPTION
Prior to this commit, (primitive) values that were merged right-to-left into `Attributes` instances were _not_ overriding existing values.

This commit resolves that issue by treating any conflicting _value_ within `Attributes#merge` as an override.