### PR TITLE
Remove `+` and `|` aliases for `Attributes#merge`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ the version links.
 
 ## main
 
+* Remove support for `Attributes#+` and `Attributes#|` aliases for
+  `Attributes#merge`
+
 * Resolve `Attributes#merge` primitive value override bug
 
 * Decorate public interfaces instead of monkey-patching private ones

--- a/lib/attributes_and_token_lists/attributes.rb
+++ b/lib/attributes_and_token_lists/attributes.rb
@@ -68,8 +68,6 @@ module AttributesAndTokenLists
 
       Attributes.new(@tag_builder, @view_context, **attributes)
     end
-    alias_method :+, :merge
-    alias_method :|, :merge
     alias_method :call, :merge
     alias_method :deep_merge, :merge
 

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -116,13 +116,6 @@ class AttributesAndTokenLists::ApplicationHelperTest < ActionView::TestCase
     assert_equal %(data-controller="one two"), tag.attributes("data-controller" => "one").merge("data-controller": "two").to_s
   end
 
-  test "tag.attributes reverse merges Attributes" do
-    one = tag.attributes(class: "one")
-    two = tag.attributes(class: class_names("two"))
-
-    assert_equal %(class="one two"), (one + two).to_s
-  end
-
   test "tag.attributes deeply merges TokenList attributes" do
     attributes = tag.attributes(data: {controller: token_list("one")}).merge(data: {controller: token_list("two")})
 


### PR DESCRIPTION
With added support for variable ordered and keyword arguments for `tag.attributes` and `with_attributes`, the short-hand notation for `Attributes#merge` isn't as necessary.

This commit removes both `+` and `|`.