### PR TITLE
Introduce `AttributesAndTokenLists.define`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ the version links.
 
 ## main
 
+* Pre-define clumps of attributes by calling `AttributesAndTokenLists.define` in
+  a `config/initializers` file, or an
+  `app/views/initializers/attributes_and_token_lists.html.erb` template
+
+  ```erb
+  <%# app/views/initializers/attributes_and_token_lists.html.erb %>
+  <%
+    AttributesAndTokenLists.define :atl do
+      define :button, tag_name: :button, class: "text-white p-4 focus:outline-none focus:ring" do
+        define :primary, class: "bg-green-500"
+        define :secondary, class: "bg-blue-500"
+        define :tertiary, class: "bg-black"
+      end
+    end
+  %>
+
+  <%# elsewhere %>
+
+  <%= atl.tag.button "Unstyled" %>            <%# => <button>Unstyled</button> %>
+  <%= atl.button.tag "Base" %>                <%# => <button class="text-white p-4 focus:outline-none focus:ring">Base</button> %>
+  <%= atl.button.primary.tag "Primary" %>     <%# => <button class="text-white p-4 focus:outline-none focus:ring bg-green-500">Primary</button> %>
+  <%= atl.button.secondary.tag "Secondary" %> <%# => <button class="text-white p-4 focus:outline-none focus:ring bg-blue-500">Secondary</button> %>
+  <%= atl.button.tertiary.tag "Tertiary" %>   <%# => <button class="text-white p-4 focus:outline-none focus:ring bg-black">Tertiary</button> %>
+
+  <%= atl.button.primary.tag.a "Primary", href: "#" %> <%# => <a class="text-white p-4 focus:outline-none focus:ring bg-green-500" href="#">Primary</a> %>
+  <%= atl.button.primary.link_to "Primary", "#" %>     <%# => <a class="text-white p-4 focus:outline-none focus:ring bg-green-500" href="#">Primary</a> %>
+  ```
+
 * Remove support for `Attributes#+` and `Attributes#|` aliases for
   `Attributes#merge`
 

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,10 @@ end
 gem "rails", rails_constraint
 gem "sprockets-rails"
 gem "net-smtp"
+gem "capybara"
+gem "action_dispatch-testing-integration-capybara",
+  github: "thoughtbot/action_dispatch-testing-integration-capybara", tag: "v0.1.0",
+  require: "action_dispatch/testing/integration/capybara/minitest"
 
 group :development do
   gem "sqlite3"

--- a/app/helpers/attributes_and_token_lists/application_helper.rb
+++ b/app/helpers/attributes_and_token_lists/application_helper.rb
@@ -15,7 +15,7 @@ module AttributesAndTokenLists
         if value.is_a?(String)
           value
         else
-          AttributesAndTokenLists::TagBuilder.new(self, value)
+          AttributesAndTokenLists::TagBuilder.new(self, value, :div)
         end
       end
     end

--- a/lib/attributes_and_token_lists.rb
+++ b/lib/attributes_and_token_lists.rb
@@ -1,6 +1,25 @@
 require "attributes_and_token_lists/version"
 require "attributes_and_token_lists/engine"
+require "attributes_and_token_lists/attributes_builder"
 
 module AttributesAndTokenLists
-  # Your code goes here...
+  mattr_accessor(:config) { ActiveSupport::OrderedOptions.new }
+
+  def self.define(name, &block)
+    builder = config.builders[name] = Class.new(AttributesBuilder)
+
+    if block.present?
+      block.arity.zero? ? builder.instance_exec(&block) : builder.yield_self(&block)
+    end
+  end
+
+  def self.define_builder_helper_methods(helpers)
+    config.builders.each do |name, builder|
+      helpers.define_method name do
+        builder.new(self)
+      end
+    end
+
+    helpers
+  end
 end

--- a/lib/attributes_and_token_lists/attribute_merger.rb
+++ b/lib/attributes_and_token_lists/attribute_merger.rb
@@ -17,7 +17,7 @@ module AttributesAndTokenLists
 
     def tag(name = nil, options = nil, open = false, escape = true)
       if name.nil? && options.nil?
-        TagBuilder.new(@view_context, @view_context.tag, [@options])
+        AttributeMerger.new(@view_context, @view_context.tag, [@options])
       else
         @view_context.tag(name, @options.merge(options.to_h))
       end

--- a/lib/attributes_and_token_lists/attributes.rb
+++ b/lib/attributes_and_token_lists/attributes.rb
@@ -37,10 +37,15 @@ module AttributesAndTokenLists
       end
     end
 
-    def initialize(view_context, tag_builder, **attributes)
+    def initialize(view_context, tag_builder, tag_name = :div, **attributes)
       @view_context = view_context
       @tag_builder = tag_builder
       @attributes = Attributes.deep_wrap_token_lists(view_context, attributes).with_indifferent_access
+      @tag_name = tag_name
+    end
+
+    def as(tag_name)
+      Attributes.new(@view_context, @tag_builder, tag_name, **@attributes)
     end
 
     def aria(**attributes)
@@ -78,8 +83,14 @@ module AttributesAndTokenLists
     end
     alias_method :with_options, :with_attributes
 
-    def tag
-      TagBuilder.new(@view_context, @view_context.tag, [self])
+    def tag(content = nil, **overrides, &block)
+      builder = TagBuilder.new(@view_context, @tag_builder, @tag_name, [self])
+
+      if content.present? || block.present?
+        builder.public_send(builder.tag_name, content, **overrides, &block)
+      else
+        builder
+      end
     end
 
     def to_s

--- a/lib/attributes_and_token_lists/attributes_builder.rb
+++ b/lib/attributes_and_token_lists/attributes_builder.rb
@@ -1,0 +1,60 @@
+module AttributesAndTokenLists
+  class AttributesBuilder
+    class_attribute :tag_name, default: :div
+
+    def self.define(name, tag_name: self.tag_name, **defaults, &block)
+      if block.present?
+        define_chainable_builder(name, tag_name, **defaults, &block)
+      else
+        define_builder(name, tag_name, **defaults)
+      end
+    end
+
+    def self.define_chainable_builder(name, tag_name, **defaults, &block)
+      builder_class = Class.new(self) do
+        self.tag_name = tag_name
+
+        block.arity.zero? ? instance_exec(&block) : yield_self(&block)
+      end
+
+      define_method name do
+        builder_class.new(@view_context, **defaults)
+      end
+    end
+
+    def self.define_builder(name, tag_name, **defaults)
+      define_method name do
+        @attributes.merge(defaults).as(tag_name)
+      end
+    end
+
+    def initialize(view_context, **attributes)
+      @view_context = view_context
+      @attributes = view_context.tag.attributes(attributes)
+    end
+
+    def tag(...)
+      @attributes.as(tag_name).tag(...)
+    end
+
+    def to_hash
+      @attributes.to_hash
+    end
+
+    def to_h
+      @attributes.to_h
+    end
+
+    def method_missing(name, *arguments, **options, &block)
+      if @view_context.respond_to?(name)
+        @view_context.public_send(name, *arguments, **@attributes.merge(options), &block)
+      else
+        super
+      end
+    end
+
+    def respond_to_missing?(name, include_private = false)
+      @view_context.respond_to?(name)
+    end
+  end
+end

--- a/lib/attributes_and_token_lists/engine.rb
+++ b/lib/attributes_and_token_lists/engine.rb
@@ -2,10 +2,22 @@ require "attributes_and_token_lists/backports"
 
 module AttributesAndTokenLists
   class Engine < ::Rails::Engine
+    config.attributes_and_token_lists = ActiveSupport::OrderedOptions.new
+    config.attributes_and_token_lists.builders = {}
+
     config.to_prepare do
       if ::ActionView::VERSION::MAJOR == 6
         ActionView::Helpers::TagHelper::TagBuilder.include AttributesAndTokenLists::Backports
       end
+
+      AttributesAndTokenLists.config = ::Rails.configuration.attributes_and_token_lists
+
+      begin
+        ApplicationController.renderer.render(template: "initializers/attributes_and_token_lists")
+      rescue ActionView::MissingTemplate
+      end
+
+      AttributesAndTokenLists.define_builder_helper_methods(ActionView::Base)
     end
   end
 end

--- a/lib/attributes_and_token_lists/tag_builder.rb
+++ b/lib/attributes_and_token_lists/tag_builder.rb
@@ -1,8 +1,11 @@
 module AttributesAndTokenLists
   class TagBuilder
-    def initialize(view_context, tag, attributes = [])
+    attr_reader :tag_name
+
+    def initialize(view_context, tag, tag_name, attributes = [])
       @view_context = view_context
       @tag = tag
+      @tag_name = tag_name
       @attributes = attributes.reduce(Attributes.new(view_context, tag), :merge)
     end
 
@@ -17,6 +20,10 @@ module AttributesAndTokenLists
 
     def with_attributes(*hashes, **overrides, &block)
       AttributeMerger.new(@view_context, self, [*hashes, overrides]).with_attributes(&block)
+    end
+
+    def to_s
+      @tag.public_send(@tag_name, **attributes)
     end
 
     def method_missing(name, content = nil, *arguments, escape: true, **options, &block)

--- a/test/attributes_and_token_lists/attributes_builder_test.rb
+++ b/test/attributes_and_token_lists/attributes_builder_test.rb
@@ -1,0 +1,147 @@
+require "test_helper"
+require "capybara/minitest"
+
+class AttributesAndTokenLists::AttributesBuilderTest < ActionView::TestCase
+  include Capybara::Minitest::Assertions
+
+  test "AttributesAndTokenLists.define declares helper" do
+    define_builder_helper_method :test_builder
+    define_builder_helper_method :another_builder
+
+    assert view.respond_to?(:test_builder), "declares helper methods"
+    assert view.respond_to?(:another_builder), "declares helper methods"
+  end
+
+  test "definitions yield the builder as an argument" do
+    define_builder_helper_method :builder do |instance|
+      instance.define :rounded, class: "rounded-full"
+    end
+
+    render inline: <<~ERB
+      <%= builder.rounded.tag "Content" %>
+    ERB
+
+    assert_css "div", class: "rounded-full", text: "Content"
+  end
+
+  test "definitions can omit the builder argument from the block" do
+    define_builder_helper_method :builder do
+      define :rounded, class: "rounded-full"
+    end
+
+    render inline: <<~ERB
+      <%= builder.rounded.tag "Content" %>
+    ERB
+
+    assert_css "div", class: "rounded-full", text: "Content"
+  end
+
+  test "definitions can declare a default tag with the tag_name: option" do
+    define_builder_helper_method :builder do
+      define :button, tag_name: :button, class: "rounded-full"
+    end
+
+    render inline: <<~ERB
+      <%= builder.button.tag "Submit" %>
+      <%= builder.button.button_tag "Submit" %>
+    ERB
+
+    assert_button "Submit", class: "rounded-full", count: 2
+  end
+
+  test "definitions can define other variants" do
+    define_builder_helper_method :builder do
+      define :button, tag_name: :button, class: "rounded-full" do
+        define :primary, class: "bg-green-500"
+      end
+    end
+
+    render inline: <<~ERB
+      <%= builder.button.tag "Base" %>
+      <%= builder.button.primary.tag "Primary" %>
+      <%= builder.button.primary.button_tag "Primary" %>
+    ERB
+
+    assert_button "Base", class: %w[rounded-full]
+    assert_button "Primary", class: %w[rounded-full bg-green-500], count: 2
+  end
+
+  test "defined attributes can render with content" do
+    define_builder_helper_method :builder do
+      define :button, tag_name: :button
+    end
+
+    render inline: <<~ERB
+      <%= builder.button.tag "Submit" %>
+    ERB
+
+    assert_button "Submit"
+  end
+
+  test "defined attributes can render without content" do
+    define_builder_helper_method :builder do
+      define :submit, tag_name: :input, type: "submit"
+    end
+
+    render inline: <<~ERB
+      <%= builder.submit.tag %>
+    ERB
+
+    assert_button type: "submit"
+  end
+
+  test "defined attributes can render with overrides" do
+    define_builder_helper_method :builder do
+      define :button, tag_name: :button, type: "submit"
+    end
+
+    render inline: <<~ERB
+      <%= builder.button.tag "Submit" %>
+      <%= builder.button.tag "Reset", type: "reset" %>
+    ERB
+
+    assert_button "Submit", type: "submit"
+    assert_button "Reset", type: "reset"
+  end
+
+  test "defined attributes can render as other tags" do
+    define_builder_helper_method :builder do
+      define :button, tag_name: :button, class: "rounded-full"
+    end
+
+    render inline: <<~ERB
+      <%= builder.button.tag "A button" %>
+      <%= builder.button.tag.input value: "An input", type: "button" %>
+      <%= builder.button.tag.a "A link", href: "#" %>
+    ERB
+
+    assert_button "A button", class: "rounded-full"
+    assert_field with: "An input", class: "rounded-full", type: "button"
+    assert_link "A link", class: "rounded-full", href: "#"
+  end
+
+  test "defined attributes splat into Action View helpers" do
+    define_builder_helper_method :builder do
+      define :button, tag_name: :button, class: "rounded-full"
+    end
+
+    render inline: <<~ERB
+      <%= form_with scope: :post, url: "/" do |form| %>
+        <%= form.button "Submit", builder.button.(class: "btn") %>
+      <% end %>
+    ERB
+
+    assert_css "form" do
+      assert_button "Submit", class: %w[rounded-full btn], type: "submit"
+    end
+  end
+
+  def page
+    @page ||= Capybara.string(rendered)
+  end
+
+  def define_builder_helper_method(name, &block)
+    AttributesAndTokenLists.define(name, &block)
+    view.extend(AttributesAndTokenLists.define_builder_helper_methods(Module.new))
+  end
+end

--- a/test/dummy/app/views/initializers/attributes_and_token_lists.html.erb
+++ b/test/dummy/app/views/initializers/attributes_and_token_lists.html.erb
@@ -1,0 +1,9 @@
+<%
+  AttributesAndTokenLists.define :atl do
+    define :button, tag_name: :button, class: "text-white p-4 focus:outline-none focus:ring" do
+      define :primary, class: "bg-green-500"
+      define :secondary, class: "bg-blue-500"
+      define :tertiary, class: "bg-black"
+    end
+  end
+%>

--- a/test/integration/attributes_builder_test.rb
+++ b/test/integration/attributes_builder_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class AttributesBuilderTest < ActionDispatch::IntegrationTest
+  test "reads configuration from app/views/initializers" do
+    post examples_path, params: {template: <<~ERB}
+      <%= atl.tag.button "Unstyled" %>
+      <%= atl.button.tag "Base" %>
+      <%= atl.button.primary.tag "Primary" %>
+      <%= atl.button.secondary.tag "Secondary" %>
+      <%= atl.button.tertiary.tag "Tertiary" %>
+      <%= atl.button.primary.tag.a "Primary", href: "#" %>
+      <%= atl.button.primary.link_to "Primary", "#" %>
+    ERB
+
+    assert_button "Unstyled", class: []
+    assert_button "Base", class: %w[text-white p-4 focus:outline-none focus:ring]
+    assert_button "Primary", class: %w[text-white p-4 focus:outline-none focus:ring bg-green-500]
+    assert_button "Secondary", class: %w[text-white p-4 focus:outline-none focus:ring bg-blue-500]
+    assert_button "Tertiary", class: %w[text-white p-4 focus:outline-none focus:ring bg-black]
+    assert_link "Primary", href: "#", class: %w[text-white p-4 focus:outline-none focus:ring bg-green-500], count: 2
+  end
+end


### PR DESCRIPTION
Pre-define clumps of attributes by calling
`AttributesAndTokenLists.define` in a `config/initializers` file, or an
`app/views/initializers/attributes_and_token_lists.html.erb` template.

```erb
<%# app/views/initializers/attributes_and_token_lists.html.erb %>
<%
  AttributesAndTokenLists.define :atl do
    define :button, tag_name: :button, class: "text-white p-4 focus:outline-none focus:ring" do
      define :primary, class: "bg-green-500"
      define :secondary, class: "bg-blue-500"
      define :tertiary, class: "bg-black"
    end
  end
%>

<%# elsewhere %>

<%= atl.tag.button "Unstyled" %>            <%# => <button>Unstyled</button> %>
<%= atl.button.tag "Base" %>                <%# => <button class="text-white p-4 focus:outline-none focus:ring">Base</button> %>
<%= atl.button.primary.tag "Primary" %>     <%# => <button class="text-white p-4 focus:outline-none focus:ring bg-green-500">Primary</button> %>
<%= atl.button.secondary.tag "Secondary" %> <%# => <button class="text-white p-4 focus:outline-none focus:ring bg-blue-500">Secondary</button> %>
<%= atl.button.tertiary.tag "Tertiary" %>   <%# => <button class="text-white p-4 focus:outline-none focus:ring bg-black">Tertiary</button> %>

<%= atl.button.primary.tag.a "Primary", href: "#" %> <%# => <a class="text-white p-4 focus:outline-none focus:ring bg-green-500" href="#">Primary</a> %>
<%= atl.button.primary.link_to "Primary", "#" %>     <%# => <a class="text-white p-4 focus:outline-none focus:ring bg-green-500" href="#">Primary</a> %>
`
