### PR TITLE
Support multiple variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ the version links.
 
 ## main
 
+* Alias `define` to `variant`, and add support for combining variants
+
+    ```ruby
+    ActiveSupport.on_load :attributes_and_token_lists do
+      define :ui do
+        define :button, tag_name: "button", class: "cursor-pointer" do
+          variant :primary, class: "text-white bg-green-500"
+          variant :rounded, class: "rounded-full"
+        end
+      end
+    end
+
+    # Elsewhere
+    ui.button(:primary, :rounded).tag "A button"
+    # => <button class="cursor-pointer text-white bg-green-500 rounded-full">A button</button>
+    ```
+
+* Move configuration out of `app/views/initializers` and into a more
+  conventional `config/initializers` file.
+
 * Pre-define clumps of attributes by calling `AttributesAndTokenLists.define` in
   a `config/initializers` file, or an
   `app/views/initializers/attributes_and_token_lists.html.erb` template

--- a/lib/attributes_and_token_lists/engine.rb
+++ b/lib/attributes_and_token_lists/engine.rb
@@ -16,6 +16,7 @@ module AttributesAndTokenLists
         ApplicationController.renderer.render(template: "initializers/attributes_and_token_lists")
       rescue ActionView::MissingTemplate
       end
+      ActiveSupport.run_load_hooks :attributes_and_token_lists, AttributesAndTokenLists
 
       AttributesAndTokenLists.define_builder_helper_methods(ActionView::Base)
     end

--- a/test/dummy/app/views/initializers/attributes_and_token_lists.html.erb
+++ b/test/dummy/app/views/initializers/attributes_and_token_lists.html.erb
@@ -1,5 +1,5 @@
 <%
-  AttributesAndTokenLists.define :atl do
+  AttributesAndTokenLists.define :view_initializer do
     define :button, tag_name: :button, class: "text-white p-4 focus:outline-none focus:ring" do
       define :primary, class: "bg-green-500"
       define :secondary, class: "bg-blue-500"

--- a/test/dummy/config/initializers/attributes_and_token_lists.html.rb
+++ b/test/dummy/config/initializers/attributes_and_token_lists.html.rb
@@ -1,0 +1,9 @@
+ActiveSupport.on_load :attributes_and_token_lists do
+  define :initializer do
+    define :button, tag_name: :button, class: "text-white p-4 focus:outline-none focus:ring" do
+      variant :primary, class: "bg-green-500"
+      variant :secondary, class: "bg-blue-500"
+      variant :tertiary, class: "bg-black"
+    end
+  end
+end

--- a/test/integration/attributes_builder_test.rb
+++ b/test/integration/attributes_builder_test.rb
@@ -3,20 +3,43 @@ require "test_helper"
 class AttributesBuilderTest < ActionDispatch::IntegrationTest
   test "reads configuration from app/views/initializers" do
     post examples_path, params: {template: <<~ERB}
-      <%= atl.tag.button "Unstyled" %>
-      <%= atl.button.tag "Base" %>
-      <%= atl.button.primary.tag "Primary" %>
-      <%= atl.button.secondary.tag "Secondary" %>
-      <%= atl.button.tertiary.tag "Tertiary" %>
-      <%= atl.button.primary.tag.a "Primary", href: "#" %>
-      <%= atl.button.primary.link_to "Primary", "#" %>
+      <%= view_initializer.tag.button "Unstyled" %>
+      <%= view_initializer.button.tag "Base" %>
+      <%= view_initializer.button.primary.tag "Primary" %>
+      <%= view_initializer.button.secondary.tag "Secondary" %>
+      <%= view_initializer.button.tertiary.tag "Tertiary" %>
+      <%= view_initializer.button.primary.tag.a "Primary", href: "#" %>
+      <%= view_initializer.button.primary.link_to "Primary", "#" %>
+      <%= view_initializer.button(:primary, :secondary, :tertiary).tag "All" %>
     ERB
 
-    assert_button "Unstyled", class: []
+    assert_button "Unstyled", class: %w[]
     assert_button "Base", class: %w[text-white p-4 focus:outline-none focus:ring]
     assert_button "Primary", class: %w[text-white p-4 focus:outline-none focus:ring bg-green-500]
     assert_button "Secondary", class: %w[text-white p-4 focus:outline-none focus:ring bg-blue-500]
     assert_button "Tertiary", class: %w[text-white p-4 focus:outline-none focus:ring bg-black]
-    assert_link "Primary", href: "#", class: %w[text-white p-4 focus:outline-none focus:ring bg-green-500], count: 2
+    assert_link "Primary", class: %w[text-white p-4 focus:outline-none focus:ring bg-green-500], href: "#", count: 2
+    assert_button "All", class: %w[text-white p-4 focus:outline-none focus:ring bg-green-500 bg-blue-500 bg-black]
+  end
+
+  test "reads configuration from config/initializers" do
+    post examples_path, params: {template: <<~ERB}
+      <%= initializer.tag.button "Unstyled" %>
+      <%= initializer.button.tag "Base" %>
+      <%= initializer.button.primary.tag "Primary" %>
+      <%= initializer.button.secondary.tag "Secondary" %>
+      <%= initializer.button.tertiary.tag "Tertiary" %>
+      <%= initializer.button.primary.tag.a "Primary", href: "#" %>
+      <%= initializer.button.primary.link_to "Primary", "#" %>
+      <%= initializer.button(:primary, :secondary, :tertiary).tag "All" %>
+    ERB
+
+    assert_button "Unstyled", class: %w[]
+    assert_button "Base", class: %w[text-white p-4 focus:outline-none focus:ring]
+    assert_button "Primary", class: %w[text-white p-4 focus:outline-none focus:ring bg-green-500]
+    assert_button "Secondary", class: %w[text-white p-4 focus:outline-none focus:ring bg-blue-500]
+    assert_button "Tertiary", class: %w[text-white p-4 focus:outline-none focus:ring bg-black]
+    assert_link "Primary", class: %w[text-white p-4 focus:outline-none focus:ring bg-green-500], href: "#", count: 2
+    assert_button "All", class: %w[text-white p-4 focus:outline-none focus:ring bg-green-500 bg-blue-500 bg-black]
   end
 end


### PR DESCRIPTION
First, move configuration out of `app/views/initializers` and into a more conventional `config/initializers` file.

Next, alias `define` to `variant`, and add support for combining variants:

```ruby
ActiveSupport.on_load :attributes_and_token_lists do
  define :ui do
    define :button, tag_name: "button", class: "cursor-pointer" do
      variant :primary, class: "text-white bg-green-500"
      variant :rounded, class: "rounded-full"
    end
  end
end

 # Elsewhere
ui.button(:primary, :rounded).tag "A button"
 # => <button class="cursor-pointer text-white bg-green-500 rounded-full">A button</button>
```