### PR TITLE
Rename `AttributesBuilder` class methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ the version links.
 
 ## main
 
+* Rename builder domain-specific language to combine `builder`, `base`, and
+  `variant`:
+
+    ```ruby
+    ActiveSupport.on_load :attributes_and_token_lists do
+      builder :ui do
+        base :button, tag_name: "button", class: "cursor-pointer" do
+          variant :primary, class: "text-white bg-green-500"
+        end
+      end
+    end
+
+    # Elsewhere
+    ui.button.primary.tag "A button"
+    # => <button class="cursor-pointer text-white bg-green-500">A button</button>
+    ```
+
+
 * Alias `define` to `variant`, and add support for combining variants
 
     ```ruby

--- a/lib/attributes_and_token_lists.rb
+++ b/lib/attributes_and_token_lists.rb
@@ -5,11 +5,11 @@ require "attributes_and_token_lists/attributes_builder"
 module AttributesAndTokenLists
   mattr_accessor(:config) { ActiveSupport::OrderedOptions.new }
 
-  def self.define(name, &block)
-    builder = config.builders[name] = Class.new(AttributesBuilder)
+  def self.builder(name, &block)
+    instance = config.builders[name] = Class.new(AttributesBuilder)
 
     if block.present?
-      block.arity.zero? ? builder.instance_exec(&block) : builder.yield_self(&block)
+      block.arity.zero? ? instance.instance_exec(&block) : instance.yield_self(&block)
     end
   end
 

--- a/test/attributes_and_token_lists/attributes_builder_test.rb
+++ b/test/attributes_and_token_lists/attributes_builder_test.rb
@@ -14,7 +14,7 @@ class AttributesAndTokenLists::AttributesBuilderTest < ActionView::TestCase
 
   test "definitions yield the builder as an argument" do
     define_builder_helper_method :builder do |instance|
-      instance.define :rounded, class: "rounded-full"
+      instance.base :rounded, class: "rounded-full"
     end
 
     render inline: <<~ERB
@@ -26,7 +26,7 @@ class AttributesAndTokenLists::AttributesBuilderTest < ActionView::TestCase
 
   test "definitions can omit the builder argument from the block" do
     define_builder_helper_method :builder do
-      define :rounded, class: "rounded-full"
+      base :rounded, class: "rounded-full"
     end
 
     render inline: <<~ERB
@@ -38,7 +38,7 @@ class AttributesAndTokenLists::AttributesBuilderTest < ActionView::TestCase
 
   test "definitions can declare a default tag with the tag_name: option" do
     define_builder_helper_method :builder do
-      define :button, tag_name: :button, class: "rounded-full"
+      base :button, tag_name: :button, class: "rounded-full"
     end
 
     render inline: <<~ERB
@@ -51,8 +51,8 @@ class AttributesAndTokenLists::AttributesBuilderTest < ActionView::TestCase
 
   test "definitions can define other variants" do
     define_builder_helper_method :builder do
-      define :button, tag_name: :button, class: "rounded-full" do
-        define :primary, class: "bg-green-500"
+      base :button, tag_name: :button, class: "rounded-full" do
+        variant :primary, class: "bg-green-500"
       end
     end
 
@@ -68,7 +68,7 @@ class AttributesAndTokenLists::AttributesBuilderTest < ActionView::TestCase
 
   test "defined attributes can render with content" do
     define_builder_helper_method :builder do
-      define :button, tag_name: :button
+      base :button, tag_name: :button
     end
 
     render inline: <<~ERB
@@ -80,7 +80,7 @@ class AttributesAndTokenLists::AttributesBuilderTest < ActionView::TestCase
 
   test "defined attributes can render without content" do
     define_builder_helper_method :builder do
-      define :submit, tag_name: :input, type: "submit"
+      base :submit, tag_name: :input, type: "submit"
     end
 
     render inline: <<~ERB
@@ -92,7 +92,7 @@ class AttributesAndTokenLists::AttributesBuilderTest < ActionView::TestCase
 
   test "defined attributes can render with overrides" do
     define_builder_helper_method :builder do
-      define :button, tag_name: :button, type: "submit"
+      base :button, tag_name: :button, type: "submit"
     end
 
     render inline: <<~ERB
@@ -106,7 +106,7 @@ class AttributesAndTokenLists::AttributesBuilderTest < ActionView::TestCase
 
   test "defined attributes can render as other tags" do
     define_builder_helper_method :builder do
-      define :button, tag_name: :button, class: "rounded-full"
+      base :button, tag_name: :button, class: "rounded-full"
     end
 
     render inline: <<~ERB
@@ -122,7 +122,7 @@ class AttributesAndTokenLists::AttributesBuilderTest < ActionView::TestCase
 
   test "defined attributes splat into Action View helpers" do
     define_builder_helper_method :builder do
-      define :button, tag_name: :button, class: "rounded-full"
+      base :button, tag_name: :button, class: "rounded-full"
     end
 
     render inline: <<~ERB
@@ -141,7 +141,7 @@ class AttributesAndTokenLists::AttributesBuilderTest < ActionView::TestCase
   end
 
   def define_builder_helper_method(name, &block)
-    AttributesAndTokenLists.define(name, &block)
+    AttributesAndTokenLists.builder(name, &block)
     view.extend(AttributesAndTokenLists.define_builder_helper_methods(Module.new))
   end
 end

--- a/test/dummy/app/views/initializers/attributes_and_token_lists.html.erb
+++ b/test/dummy/app/views/initializers/attributes_and_token_lists.html.erb
@@ -1,9 +1,9 @@
 <%
-  AttributesAndTokenLists.define :view_initializer do
-    define :button, tag_name: :button, class: "text-white p-4 focus:outline-none focus:ring" do
-      define :primary, class: "bg-green-500"
-      define :secondary, class: "bg-blue-500"
-      define :tertiary, class: "bg-black"
+  AttributesAndTokenLists.builder :view_initializer do
+    base :button, tag_name: :button, class: "text-white p-4 focus:outline-none focus:ring" do
+      variant :primary, class: "bg-green-500"
+      variant :secondary, class: "bg-blue-500"
+      variant :tertiary, class: "bg-black"
     end
   end
 %>

--- a/test/dummy/config/initializers/attributes_and_token_lists.html.rb
+++ b/test/dummy/config/initializers/attributes_and_token_lists.html.rb
@@ -1,6 +1,6 @@
 ActiveSupport.on_load :attributes_and_token_lists do
-  define :initializer do
-    define :button, tag_name: :button, class: "text-white p-4 focus:outline-none focus:ring" do
+  builder :initializer do
+    base :button, tag_name: :button, class: "text-white p-4 focus:outline-none focus:ring" do
       variant :primary, class: "bg-green-500"
       variant :secondary, class: "bg-blue-500"
       variant :tertiary, class: "bg-black"


### PR DESCRIPTION
Reduce the surface area of the `AttributesBuilder` class interface to by removing the `.define_builder` and `.define_chainable_builder` methods, and replace them with `.base` and `.variant`.

```ruby
ActiveSupport.on_load :attributes_and_token_lists do
  builder :ui do
    base :button, tag_name: "button", class: "cursor-pointer" do
      variant :primary, class: "text-white bg-green-500"
    end
  end
end

 # Elsewhere
ui.button.primary.tag "A button"
 # => <button class="cursor-pointer text-white bg-green-500">A button</button>
```