### PR TITLE
Gracefully handle `nil` when combining variants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
           node-version: "14"
       - uses: "ruby/setup-ruby@v1"
         with:
+          rubygems: 3.3.13
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ the version links.
 
 ## main
 
+* Bug: gracefully resolve `nil` value when combining variants
+
 * Rename builder domain-specific language to combine `builder`, `base`, and
   `variant`:
 

--- a/lib/attributes_and_token_lists/attributes_builder.rb
+++ b/lib/attributes_and_token_lists/attributes_builder.rb
@@ -13,7 +13,7 @@ module AttributesAndTokenLists
         define_method name do |*variants|
           base = builder_class.new(@view_context, **defaults)
 
-          values = variants.map { |variant| base.public_send(variant) }
+          values = variants.compact.map { |variant| base.public_send(variant) }
 
           builder_class.new(@view_context, **values.reduce(base, :merge))
         end

--- a/test/attributes_and_token_lists/attributes_builder_test.rb
+++ b/test/attributes_and_token_lists/attributes_builder_test.rb
@@ -66,6 +66,25 @@ class AttributesAndTokenLists::AttributesBuilderTest < ActionView::TestCase
     assert_button "Primary", class: %w[rounded-full bg-green-500], count: 2
   end
 
+  test "variants can be combined" do
+    define_builder_helper_method :builder do
+      base :button, tag_name: :button do
+        variant :primary, class: "bg-green-500"
+        variant :rounded, class: "rounded-full"
+      end
+    end
+
+    render inline: <<~ERB
+      <%= builder.button(nil).tag "Base" %>
+      <%= builder.button(:primary).tag "Primary" %>
+      <%= builder.button(:primary, :rounded).button_tag "Primary Rounded" %>
+    ERB
+
+    assert_button "Base", class: %w[]
+    assert_button "Primary", exact: true, class: %w[bg-green-500], count: 1
+    assert_button "Primary Rounded", class: %w[bg-green-500 rounded-full], count: 1
+  end
+
   test "defined attributes can render with content" do
     define_builder_helper_method :builder do
       base :button, tag_name: :button


### PR DESCRIPTION
When combining variants (for example, `builder.button(:primary, :rounded)`), ignore any values passed as `nil`:

```ruby
builder.button(nil, :primary) == builder.button.primary
```