### PR TITLE
Bug: support attributes for self-closing elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ the version links.
 
 ## main
 
+* Bug: support attribute overrides for unclosed elements (for example,
+  `<input>`)
+
 * Bug: gracefully resolve `nil` value when combining variants
 
 * Rename builder domain-specific language to combine `builder`, `base`, and

--- a/lib/attributes_and_token_lists/attributes.rb
+++ b/lib/attributes_and_token_lists/attributes.rb
@@ -86,7 +86,7 @@ module AttributesAndTokenLists
     def tag(content = nil, **overrides, &block)
       builder = TagBuilder.new(@view_context, @tag_builder, @tag_name, [self])
 
-      if content.present? || block.present?
+      if content.present? || overrides.present? || block.present?
         builder.public_send(builder.tag_name, content, **overrides, &block)
       else
         builder

--- a/test/attributes_and_token_lists/attributes_builder_test.rb
+++ b/test/attributes_and_token_lists/attributes_builder_test.rb
@@ -99,14 +99,21 @@ class AttributesAndTokenLists::AttributesBuilderTest < ActionView::TestCase
 
   test "defined attributes can render without content" do
     define_builder_helper_method :builder do
-      base :submit, tag_name: :input, type: "submit"
+      base :input, tag_name: :input do
+        variant :text, type: "text"
+        variant :submit, type: "submit"
+      end
     end
 
     render inline: <<~ERB
-      <%= builder.submit.tag %>
+      <%= builder.input.tag value: "Default" %>
+      <%= builder.input.text.tag value: "Text" %>
+      <%= builder.input.submit.tag value: "Submit"%>
     ERB
 
-    assert_button type: "submit"
+    assert_field(with: "Default", exact: true, count: 1) { _1["type"].nil? }
+    assert_field(type: "text", with: "Text", count: 1)
+    assert_button("Submit", type: "submit", count: 1)
   end
 
   test "defined attributes can render with overrides" do


### PR DESCRIPTION
Prior to this commit, the attribute builder would ignore calls to self-closing elements that don't have content or block values.

For example, `builder.input.tag value: "an input [value]"` would be ignored.