### PR TITLE
Change: Combine variant syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ the version links.
 
 ## main
 
+* Change: combine variants with `#[]`
+
+    ```ruby
+    define :button, tag_name: "button", class: "cursor-pointer" do
+      variant :primary, class: "text-white bg-green-500"
+      variant :rounded, class: "rounded-full"
+    end
+
+    # before
+    ui.button(:primary, :rounded).tag "A button"
+
+    # after
+    ui.button[:primary, :rounded].tag "A button"
+    ```
+
 * Bug: support attribute overrides for unclosed elements (for example,
   `<input>`)
 

--- a/test/attributes_and_token_lists/attributes_builder_test.rb
+++ b/test/attributes_and_token_lists/attributes_builder_test.rb
@@ -75,14 +75,16 @@ class AttributesAndTokenLists::AttributesBuilderTest < ActionView::TestCase
     end
 
     render inline: <<~ERB
-      <%= builder.button(nil).tag "Base" %>
-      <%= builder.button(:primary).tag "Primary" %>
-      <%= builder.button(:primary, :rounded).button_tag "Primary Rounded" %>
+      <%= builder.button[nil].tag "Base" %>
+      <%= builder.button[:primary].tag "Primary" %>
+      <%= builder.button[:primary, :rounded].button_tag "Primary Rounded" %>
+      <%= builder.button[[:primary, :rounded]].button_tag "Primary Rounded Array" %>
     ERB
 
     assert_button "Base", class: %w[]
     assert_button "Primary", exact: true, class: %w[bg-green-500], count: 1
-    assert_button "Primary Rounded", class: %w[bg-green-500 rounded-full], count: 1
+    assert_button "Primary Rounded", exact: true, class: %w[bg-green-500 rounded-full], count: 1
+    assert_button "Primary Rounded Array", exact: true, class: %w[bg-green-500 rounded-full], count: 1
   end
 
   test "defined attributes can render with content" do

--- a/test/integration/attributes_builder_test.rb
+++ b/test/integration/attributes_builder_test.rb
@@ -10,7 +10,7 @@ class AttributesBuilderTest < ActionDispatch::IntegrationTest
       <%= view_initializer.button.tertiary.tag "Tertiary" %>
       <%= view_initializer.button.primary.tag.a "Primary", href: "#" %>
       <%= view_initializer.button.primary.link_to "Primary", "#" %>
-      <%= view_initializer.button(:primary, :secondary, :tertiary).tag "All" %>
+      <%= view_initializer.button[:primary, :secondary, :tertiary].tag "All" %>
     ERB
 
     assert_button "Unstyled", class: %w[]
@@ -31,7 +31,7 @@ class AttributesBuilderTest < ActionDispatch::IntegrationTest
       <%= initializer.button.tertiary.tag "Tertiary" %>
       <%= initializer.button.primary.tag.a "Primary", href: "#" %>
       <%= initializer.button.primary.link_to "Primary", "#" %>
-      <%= initializer.button(:primary, :secondary, :tertiary).tag "All" %>
+      <%= initializer.button[:primary, :secondary, :tertiary].tag "All" %>
     ERB
 
     assert_button "Unstyled", class: %w[]


### PR DESCRIPTION
Combine variants with `#[]` instead of as builder arguments:

```ruby
  define :button, tag_name: "button", class: "cursor-pointer" do
    variant :primary, class: "text-white bg-green-500"
    variant :rounded, class: "rounded-full"
  end

  # before
  ui.button(:primary, :rounded).tag "A button"

  # after
  ui.button[:primary, :rounded].tag "A button"
```