### PR TITLE
Define `ActionView::Helpers::FormBuilder#with_attributes`

### DIFF
--- a/lib/attributes_and_token_lists/engine.rb
+++ b/lib/attributes_and_token_lists/engine.rb
@@ -1,9 +1,14 @@
 require "attributes_and_token_lists/backports"
+require "attributes_and_token_lists/form_builder_extensions"
 
 module AttributesAndTokenLists
   class Engine < ::Rails::Engine
     config.attributes_and_token_lists = ActiveSupport::OrderedOptions.new
     config.attributes_and_token_lists.builders = {}
+
+    ActiveSupport.on_load :action_view do
+      ActionView::Helpers::FormBuilder.include AttributesAndTokenLists::FormBuilderExtensions
+    end
 
     config.to_prepare do
       if ::ActionView::VERSION::MAJOR == 6

--- a/lib/attributes_and_token_lists/form_builder_extensions.rb
+++ b/lib/attributes_and_token_lists/form_builder_extensions.rb
@@ -1,0 +1,22 @@
+module AttributesAndTokenLists::FormBuilderExtensions
+  # Inspired by `Object#with_options`, when the `with_attributes` helper
+  # is called with a block,
+  # it yields a block argument that merges options into a base set of
+  # attributes. For example:
+  #
+  #   form.with_attributes class: "font-bold" do |styled|
+  #     styled.text_field :name
+  #     #=> <input class="font-bold" type="text" name="name" id="name" />
+  #   end
+  #
+  # When the block is omitted, the object that would be the block
+  # parameter is returned:
+  #
+  #   styled = form.with_attributes class: "font-bold"
+  #   styled.text_field :name
+  #   #=> <input class="font-bold" type="text" name="name" id="name" />
+  #
+  def with_attributes(*hashes, **overrides, &block)
+    AttributesAndTokenLists::AttributeMerger.new(@template, self, [*hashes, overrides]).with_attributes(&block)
+  end
+end

--- a/test/integration/helpers_test.rb
+++ b/test/integration/helpers_test.rb
@@ -10,4 +10,34 @@ class HelpersTest < ActionDispatch::IntegrationTest
       <button id="1" class="one two" hidden="hidden"></button>
     HTML
   end
+
+  test "extends FormBuilder instances with_attributes (block)" do
+    post examples_path, params: {template: <<~ERB}
+      <%= form_with url: "/", authenticity_token: false, enforce_utf8: false do |form| %>
+        <% form.with_attributes class: "font-bold" do |special_form| %>
+          <%= special_form.text_field :text, class: "text" %>
+        <% end %>
+      <% end %>
+    ERB
+
+    assert_equal <<~HTML.strip, response.body
+      <form action="/" accept-charset="UTF-8" method="post">
+          <input class="font-bold text" type="text" name="text" id="text" />
+      </form>
+    HTML
+  end
+
+  test "extends FormBuilder instances with_attributes (instance)" do
+    post examples_path, params: {template: <<~ERB}
+      <%= form_with url: "/", authenticity_token: false, enforce_utf8: false do |form| %>
+        <%= form.with_attributes(class: "font-bold").text_field :text, class: "text" %>
+      <% end %>
+    ERB
+
+    assert_equal <<~HTML.strip, response.body
+      <form action="/" accept-charset="UTF-8" method="post">
+        <input class="font-bold text" type="text" name="text" id="text" />
+      </form>
+    HTML
+  end
 end


### PR DESCRIPTION
Extend the [ActionView::Helpers::FormBuilder][] to respond to `#with_attributes`, so that calling templates declare local clusters of attributes.

For example, consider a view partial (with named block support powered by [nice_partials][]) that yields the builder with pre-populated styles for the `<label>` and the field element:

```erb
<%# app/views/application/form_builder/_labelled_field.html.erb %>

<div class="flex flex-col gap-x-4">
  <%= partial.label.yield form.with_attributes(class: "font-bold") %>
  <%= partial.field.yield form.with_attributes(class: "border border-1 rounded-full") %>
</div>

<%# app/views/posts/_form.html.erb %>

<%= form_with model: post do |form| %>
  <%= render "application/form_builder/labelled_field", form: do |styled| %>
    <% styled.label { |builder| builder.label :name } %>
    <% styled.field { |builder| builder.text_field :name } %>
  <% end %>

  <%= form.button %>
<% end %>
```

[ActionView::Helpers::FormBuilder]: https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html
[nice_partials]: https://github.com/bullet-train-co/nice_partials