### PR TITLE
Import `ActiveSupport::OptionMerger` implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ the version links.
 
 ## main
 
+* Inline `ActiveSupport::OptionMerger` into `AttributesAndTokenLists::AttributeMerger` to handle `AttributesAndTokenLists::Attributes` instances
+
 * Change: combine variants with `#[]`
 
     ```ruby

--- a/lib/attributes_and_token_lists/attribute_merger.rb
+++ b/lib/attributes_and_token_lists/attribute_merger.rb
@@ -1,12 +1,17 @@
 module AttributesAndTokenLists
-  class AttributeMerger < ActiveSupport::OptionMerger
+  class AttributeMerger
+    instance_methods.each do |method|
+      undef_method(method) unless method.start_with?("__", "instance_eval", "class", "object_id")
+    end
+
     def initialize(view_context, context, options)
       @view_context = view_context
-      super context, @view_context.tag.attributes(*options)
+      @context = context
+      @attributes = @view_context.tag.attributes(*options)
     end
 
     def with_attributes(*hashes, **overrides, &block)
-      attribute_merger = AttributeMerger.new(@view_context, @context, [@options, *hashes, overrides])
+      attribute_merger = AttributeMerger.new(@view_context, @context, [@attributes, *hashes, overrides])
 
       if block.nil?
         attribute_merger
@@ -14,26 +19,79 @@ module AttributesAndTokenLists
         block.arity.zero? ? attribute_merger.instance_eval(&block) : block.call(attribute_merger)
       end
     end
+    alias_method :with_options, :with_attributes
 
     def tag(name = nil, options = nil, open = false, escape = true)
       if name.nil? && options.nil?
-        AttributeMerger.new(@view_context, @view_context.tag, [@options])
+        AttributeMerger.new(@view_context, @view_context.tag, [@attributes])
       else
-        @view_context.tag(name, @options.merge(options.to_h))
+        @view_context.tag(name, @attributes.merge(options.to_h))
       end
     end
 
     def to_hash
-      @options.to_hash
+      @attributes.to_hash
     end
 
     def to_h
-      @options.to_h
+      @attributes.to_h
     end
 
     def inspect
       "#<%<class>s:0x%<addr>08x context=%<context>s>" %
         {class: self.class, addr: object_id * 2, context: @context.inspect}
+    end
+
+    private
+
+    def method_missing(method, *arguments, &block)
+      options = nil
+      if arguments.size == 1 && arguments.first.is_a?(Proc)
+        proc = arguments.shift
+        arguments << ->(*args) { @attributes.merge(proc.call(*args)) }
+      elsif arguments.last.respond_to?(:to_hash)
+        options = @attributes.merge(arguments.pop)
+      else
+        options = @attributes
+      end
+
+      if options
+        if __options_are_keyword_arguments?(method)
+          @context.__send__(method, *arguments, **options, &block)
+        else
+          @context.__send__(method, *arguments, options, &block)
+        end
+      else
+        @context.__send__(method, *arguments, &block)
+      end
+    end
+
+    def respond_to_missing?(*arguments)
+      @context.respond_to?(*arguments)
+    end
+
+    def __options_are_keyword_arguments?(method)
+      default_value = ::RUBY_VERSION >= "2.7.0"
+
+      if @context.respond_to?(method)
+        parameters = @context.method(method).parameters
+        option, block = parameters.last(2)
+
+        option =
+          if option.nil? || (option.present? && block.nil? && option.first == :block)
+            []
+          elsif block.present? && block.first == :keyrest
+            block
+          else
+            option
+          end
+
+        option.first == :keyrest
+      else
+        default_value
+      end
+    rescue NoMethodError
+      default_value
     end
   end
 end

--- a/lib/attributes_and_token_lists/engine.rb
+++ b/lib/attributes_and_token_lists/engine.rb
@@ -6,10 +6,6 @@ module AttributesAndTokenLists
     config.attributes_and_token_lists = ActiveSupport::OrderedOptions.new
     config.attributes_and_token_lists.builders = {}
 
-    ActiveSupport.on_load :action_view do
-      ActionView::Helpers::FormBuilder.include AttributesAndTokenLists::FormBuilderExtensions
-    end
-
     config.to_prepare do
       if ::ActionView::VERSION::MAJOR == 6
         ActionView::Helpers::TagHelper::TagBuilder.include AttributesAndTokenLists::Backports

--- a/lib/attributes_and_token_lists/form_builder_extensions.rb
+++ b/lib/attributes_and_token_lists/form_builder_extensions.rb
@@ -19,4 +19,9 @@ module AttributesAndTokenLists::FormBuilderExtensions
   def with_attributes(*hashes, **overrides, &block)
     AttributesAndTokenLists::AttributeMerger.new(@template, self, [*hashes, overrides]).with_attributes(&block)
   end
+  alias_method :with_options, :with_attributes
+end
+
+ActiveSupport.on_load :action_view do
+  ActionView::Helpers::FormBuilder.include AttributesAndTokenLists::FormBuilderExtensions
 end

--- a/lib/attributes_and_token_lists/tag_builder.rb
+++ b/lib/attributes_and_token_lists/tag_builder.rb
@@ -38,8 +38,8 @@ module AttributesAndTokenLists
       @tag.public_send(name, content, escape: escape, **attributes(*arguments, **options), &block)
     end
 
-    def respond_to_missing?(name, include_private = false)
-      @tag.respond_to_missing?(name, include_private)
+    def respond_to_missing?(*arguments)
+      true
     end
   end
 end

--- a/test/integration/helpers_test.rb
+++ b/test/integration/helpers_test.rb
@@ -6,38 +6,66 @@ class HelpersTest < ActionDispatch::IntegrationTest
       <%= tag.attributes({id: 1, class: "one"}, {hidden: true}, class: "two").tag.button %>
     ERB
 
-    assert_equal <<~HTML, response.body
+    assert_html_equal <<~HTML, response.body
       <button id="1" class="one two" hidden="hidden"></button>
+    HTML
+  end
+
+  test "merges attributes into **keyword arguments" do
+    post examples_path, params: {template: <<~ERB}
+      <%= with_attributes(class: "attribute-default").with_options(class: "options-default").form_with class: "override" %>
+    ERB
+
+    assert_html_equal <<~HTML, response.body
+      <form class="attribute-default options-default override" action="/examples" accept-charset="UTF-8" method="post">
+    HTML
+  end
+
+  test "merges attributes into **keyword arguments passed with a block" do
+    post examples_path, params: {template: <<~ERB}
+      <%= with_attributes(class: "attribute-default").with_options(class: "options-default").form_with class: "override", authenticity_token: false, enforce_utf8: false do %>
+      <% end %>
+    ERB
+
+    assert_html_equal <<~HTML, response.body
+      <form class="attribute-default options-default override" action="/examples" accept-charset="UTF-8" method="post">
+      </form>
     HTML
   end
 
   test "extends FormBuilder instances with_attributes (block)" do
     post examples_path, params: {template: <<~ERB}
-      <%= form_with url: "/", authenticity_token: false, enforce_utf8: false do |form| %>
+      <%= fields do |form| %>
         <% form.with_attributes class: "font-bold" do |special_form| %>
+          <%= special_form.text_field :text, class: "text" %>
+        <% end %>
+        <% form.with_options class: "font-bold" do |special_form| %>
           <%= special_form.text_field :text, class: "text" %>
         <% end %>
       <% end %>
     ERB
 
-    assert_equal <<~HTML.strip, response.body
-      <form action="/" accept-charset="UTF-8" method="post">
-          <input class="font-bold text" type="text" name="text" id="text" />
-      </form>
+    assert_html_equal <<~HTML, response.body
+      <input class="font-bold text" type="text" name="text" id="text" />
+      <input class="font-bold text" type="text" name="text" id="text" />
     HTML
   end
 
   test "extends FormBuilder instances with_attributes (instance)" do
     post examples_path, params: {template: <<~ERB}
-      <%= form_with url: "/", authenticity_token: false, enforce_utf8: false do |form| %>
+      <%= fields do |form| %>
         <%= form.with_attributes(class: "font-bold").text_field :text, class: "text" %>
+        <%= form.with_options(class: "font-bold").text_field :text, class: "text" %>
       <% end %>
     ERB
 
-    assert_equal <<~HTML.strip, response.body
-      <form action="/" accept-charset="UTF-8" method="post">
-        <input class="font-bold text" type="text" name="text" id="text" />
-      </form>
+    assert_html_equal <<~HTML, response.body
+      <input class="font-bold text" type="text" name="text" id="text" />
+      <input class="font-bold text" type="text" name="text" id="text" />
     HTML
+  end
+
+  def assert_html_equal(expected, actual, *rest)
+    assert_equal expected.squish, actual.squish, *rest
   end
 end


### PR DESCRIPTION
The [ActiveSupport::OptionMerger][] is marked as `:nodoc:`, and is intended to be private. It also coerces any `options` arguments into keyword arguments by double-splatting them (with `**`).

This commit inlines that class' implementation into the `AttributeMerger` class, and adds a special case for methods that accept `options` as a final `Hash` argument, of which Action View (and Rails in general) has many. When encountering a final `Hash`, pass the `Attributes` instance instead, without splatting.

When the final argument is a "keyrest" like `**options`, splat the `Attributes` instance into a `Hash`.

[ActiveSupport::OptionMerger]: https://github.com/rails/rails/blob/v7.0.4.1/activesupport/lib/active_support/option_merger.rb#L6