### PR TITLE
Add `with_attributes` support to Action View Collection Builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ the version links.
 
 ## main
 
+* Add `#with_attributes` support to Action View's collection helpers (like [collection_check_boxes][]) in the same style as `FormBuilder#with_attributes`
+
+  ```ruby
+  collection_check_boxes :record, :choice, ["a", "b"], :to_s, :to_s do |builder|
+    builder.with_attributes class: "font-bold" do |styled|
+      styled.check_box
+      #=> <input class="font-bold" type="checkbox" value="a" name="record[choice][]" id="record_choice_a" />
+    end
+  end
+  ```
+
+  [collection_check_boxes]: https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/FormOptionsHelper.html#method-i-collection_check_boxes
+
 * Inline `ActiveSupport::OptionMerger` into `AttributesAndTokenLists::AttributeMerger` to handle `AttributesAndTokenLists::Attributes` instances
 
 * Change: combine variants with `#[]`

--- a/lib/attributes_and_token_lists/collection_builder_extensions.rb
+++ b/lib/attributes_and_token_lists/collection_builder_extensions.rb
@@ -1,0 +1,33 @@
+module AttributesAndTokenLists::CollectionBuilderExtensions
+  # Inspired by `Object#with_options`, when the `with_attributes` helper
+  # is called with a block,
+  # it yields a block argument that merges options into a base set of
+  # attributes. For example:
+  #
+  #   builder.with_attributes class: "font-bold" do |styled|
+  #     styled.check_box
+  #     #=> <input class="font-bold" type="checkbox" value="a" name="record[choice][]" id="record_choice_a" />
+  #   end
+  #
+  # When the block is omitted, the object that would be the block
+  # parameter is returned:
+  #
+  #   styled = builder.with_attributes class: "font-bold"
+  #   styled.check_box
+  #   #=> <input class="font-bold" type="checkbox" value="a" name="record[choice][]" id="record_choice_a" />
+  #
+  def with_attributes(*hashes, **overrides, &block)
+    attribute_merger = AttributesAndTokenLists::AttributeMerger.new(@template_object, self, [@input_html_options])
+
+    attribute_merger.with_attributes(*hashes, **overrides, &block)
+  end
+  alias_method :with_options, :with_attributes
+end
+
+ActiveSupport.on_load :action_view do
+  require "action_view/helpers/tags/collection_helpers"
+
+  ActionView::Helpers::Tags::CollectionHelpers::Builder.include AttributesAndTokenLists::CollectionBuilderExtensions
+rescue LoadError
+  # skip extension
+end

--- a/lib/attributes_and_token_lists/engine.rb
+++ b/lib/attributes_and_token_lists/engine.rb
@@ -1,4 +1,5 @@
 require "attributes_and_token_lists/backports"
+require "attributes_and_token_lists/collection_builder_extensions"
 require "attributes_and_token_lists/form_builder_extensions"
 
 module AttributesAndTokenLists

--- a/test/integration/helpers_test.rb
+++ b/test/integration/helpers_test.rb
@@ -65,6 +65,38 @@ class HelpersTest < ActionDispatch::IntegrationTest
     HTML
   end
 
+  test "extends collection Builder instances with_attributes (block)" do
+    post examples_path, params: {template: <<~ERB}
+      <%= collection_check_boxes :record, :choice, ["a"], :to_s, :to_s, {include_hidden: false}, class: "default" do |builder| %>
+        <% builder.with_attributes class: "override" do |special_builder| %>
+          <%= special_builder.check_box %>
+        <% end %>
+        <% builder.with_options class: "override" do |special_builder| %>
+          <%= special_builder.check_box %>
+        <% end %>
+      <% end %>
+    ERB
+
+    assert_html_equal <<~HTML, response.body
+      <input class="default override" type="checkbox" value="a" name="record[choice][]" id="record_choice_a" />
+      <input class="default override" type="checkbox" value="a" name="record[choice][]" id="record_choice_a" />
+    HTML
+  end
+
+  test "extends collection Builder instances with_attributes (instance)" do
+    post examples_path, params: {template: <<~ERB}
+      <%= collection_check_boxes :record, :choice, ["a"], :to_s, :to_s, {include_hidden: false}, class: "default" do |builder| %>
+        <%= builder.with_attributes(class: "override").check_box %>
+        <%= builder.with_options(class: "override").check_box %>
+      <% end %>
+    ERB
+
+    assert_html_equal <<~HTML, response.body
+      <input class="default override" type="checkbox" value="a" name="record[choice][]" id="record_choice_a" />
+      <input class="default override" type="checkbox" value="a" name="record[choice][]" id="record_choice_a" />
+    HTML
+  end
+
   def assert_html_equal(expected, actual, *rest)
     assert_equal expected.squish, actual.squish, *rest
   end


### PR DESCRIPTION
Add `#with_attributes` support to Action View's collection helpers (like [collection_check_boxes][]) in the same style as
`FormBuilder#with_attributes`

```ruby
collection_check_boxes :record, :choice, ["a", "b"], :to_s, :to_s do |builder|
  builder.with_attributes class: "font-bold" do |styled|
    styled.check_box
    #=> <input class="font-bold" type="checkbox" value="a" name="record[choice][]" id="record_choice_a" />
  end
end
```

[collection_check_boxes]: https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/FormOptionsHelper.html#method-i-collection_check_boxes